### PR TITLE
add restricted mode for the catalog

### DIFF
--- a/percona-dbaas-catalog.yaml
+++ b/percona-dbaas-catalog.yaml
@@ -7,6 +7,8 @@ spec:
   displayName: Percona DBaaS Catalog
   publisher: Percona
   sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: restricted
   image: docker.io/percona/dbaas-catalog:latest
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
similar to https://github.com/operator-framework/operator-lifecycle-manager/issues/2914 we have an issue with the newest k8s.

This fixes it, and also works with 1.23.x k8s.